### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ x-common: &common
     # - "69:69"
     # HTTP
     - "80:80"
+    # HTTPS
+    - "443:443"
     # NTP
     # - "123:123"
     # SNMP


### PR DESCRIPTION
HTTPS is marked true in 
`data/.opencanary.conf`

Adding here to be consistent and open that port.

https://github.com/thinkst/opencanary/blob/master/data/.opencanary.conf#L23